### PR TITLE
Add tests for Window UI properties

### DIFF
--- a/tests/Fluent.UITests/ControlTests/Data/WindowTests.xaml
+++ b/tests/Fluent.UITests/ControlTests/Data/WindowTests.xaml
@@ -1,0 +1,101 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:ut="clr-namespace:Fluent.UITests.TestUtilities">
+    <ResourceDictionary.MergedDictionaries>
+
+        <ut:TestDictionary Name="Light">
+            <ut:TestDictionary.MergedDictionaries>
+                <ut:TestDictionary Source="/Fluent.UITests;component/ResourceTests/Data/Light.Test.xaml" />
+
+                <ut:TestDictionary Name="Default">
+                    <!-- Window Control Properties -->
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
+                    <!-- not defined in wpf code-->
+                    <!--<SolidColorBrush x:Key="Window_BorderBrush" Color="{StaticResource TextFillColorPrimary}"/>
+                    <Thickness x:Key="Window_BorderThickness">11,5,11,6</Thickness>-->
+                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>                 
+                    
+                    <!-- Window ResizeGrip Properties -->
+                    <HorizontalAlignment x:Key="WindowResizeGrip_HorizontalAlignment">Right</HorizontalAlignment>
+                    <VerticalAlignment x:Key="WindowResizeGrip_VerticalAlignment">Bottom</VerticalAlignment>
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Collapsed</Visibility>
+                    <sys:Boolean x:Key="WindowResizeGrip_IsTabStop">False</sys:Boolean>
+                </ut:TestDictionary>
+                
+                <ut:TestDictionary Name="CanResizeGrip_NormalWindow">
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />                   
+                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="Disabled">
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent"/>                   
+                </ut:TestDictionary>
+            </ut:TestDictionary.MergedDictionaries>
+        </ut:TestDictionary>
+
+        <ut:TestDictionary Name="Dark">
+            <ut:TestDictionary.MergedDictionaries>
+                <ut:TestDictionary Source="/Fluent.UITests;component/ResourceTests/Data/Dark.Test.xaml" />
+
+                <ut:TestDictionary Name="Default">
+                    <!-- Window Control Properties -->
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
+                    <!-- not defined in wpf code-->
+                    <!--<SolidColorBrush x:Key="Window_BorderBrush" Color="{StaticResource TextFillColorPrimary}"/>
+     <Thickness x:Key="Window_BorderThickness">11,5,11,6</Thickness>-->
+                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>
+
+                    <!-- Window ResizeGrip Properties -->
+                    <HorizontalAlignment x:Key="WindowResizeGrip_HorizontalAlignment">Right</HorizontalAlignment>
+                    <VerticalAlignment x:Key="WindowResizeGrip_VerticalAlignment">Bottom</VerticalAlignment>
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Collapsed</Visibility>
+                    <sys:Boolean x:Key="WindowResizeGrip_IsTabStop">False</sys:Boolean>
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="CanResizeGrip_NormalWindow">
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
+                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="Disabled">
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent"/>
+                </ut:TestDictionary>
+            </ut:TestDictionary.MergedDictionaries>
+        </ut:TestDictionary>
+
+        <ut:TestDictionary Name="HC">
+            <ut:TestDictionary.MergedDictionaries>
+                <ut:TestDictionary Source="/Fluent.UITests;component/ResourceTests/Data/HC.Test.xaml" />
+                <ut:TestDictionary Name="Default">
+                    <!-- Window Control Properties -->
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
+                    <!-- not defined in wpf code-->
+                    <!--<SolidColorBrush x:Key="Window_BorderBrush" Color="{StaticResource TextFillColorPrimary}"/>
+                    <Thickness x:Key="Window_BorderThickness">11,5,11,6</Thickness>-->
+                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource SystemColorWindowTextColor}"/>
+
+                    <!-- Window ResizeGrip Properties -->
+                    <HorizontalAlignment x:Key="WindowResizeGrip_HorizontalAlignment">Right</HorizontalAlignment>
+                    <VerticalAlignment x:Key="WindowResizeGrip_VerticalAlignment">Bottom</VerticalAlignment>
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Collapsed</Visibility>
+                    <sys:Boolean x:Key="WindowResizeGrip_IsTabStop">False</sys:Boolean>
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="CanResizeGrip_NormalWindow">
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
+                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource SystemColorWindowTextColor}"/>
+                </ut:TestDictionary>
+
+                <ut:TestDictionary Name="Disabled">
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent"/>
+                </ut:TestDictionary>
+
+
+            </ut:TestDictionary.MergedDictionaries>
+        </ut:TestDictionary>
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>

--- a/tests/Fluent.UITests/ControlTests/Data/WindowTests.xaml
+++ b/tests/Fluent.UITests/ControlTests/Data/WindowTests.xaml
@@ -10,8 +10,7 @@
 
                 <ut:TestDictionary Name="Default">
                     <!-- Window Control Properties -->
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
-                    <!-- not defined in wpf code-->
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />                   
                     <!--<SolidColorBrush x:Key="Window_BorderBrush" Color="{StaticResource TextFillColorPrimary}"/>
                     <Thickness x:Key="Window_BorderThickness">11,5,11,6</Thickness>-->
                     <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>                 
@@ -24,14 +23,9 @@
                 </ut:TestDictionary>
                 
                 <ut:TestDictionary Name="CanResizeGrip_NormalWindow">
-                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />                   
-                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>                    
                 </ut:TestDictionary>
-
-                <ut:TestDictionary Name="Disabled">
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent"/>                   
-                </ut:TestDictionary>
+                
             </ut:TestDictionary.MergedDictionaries>
         </ut:TestDictionary>
 
@@ -41,10 +35,9 @@
 
                 <ut:TestDictionary Name="Default">
                     <!-- Window Control Properties -->
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
-                    <!-- not defined in wpf code-->
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />                   
                     <!--<SolidColorBrush x:Key="Window_BorderBrush" Color="{StaticResource TextFillColorPrimary}"/>
-     <Thickness x:Key="Window_BorderThickness">11,5,11,6</Thickness>-->
+                    <Thickness x:Key="Window_BorderThickness">11,5,11,6</Thickness>-->
                     <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>
 
                     <!-- Window ResizeGrip Properties -->
@@ -55,14 +48,9 @@
                 </ut:TestDictionary>
 
                 <ut:TestDictionary Name="CanResizeGrip_NormalWindow">
-                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
-                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource TextFillColorPrimary}"/>
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>                  
                 </ut:TestDictionary>
-
-                <ut:TestDictionary Name="Disabled">
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent"/>
-                </ut:TestDictionary>
+              
             </ut:TestDictionary.MergedDictionaries>
         </ut:TestDictionary>
 
@@ -71,8 +59,7 @@
                 <ut:TestDictionary Source="/Fluent.UITests;component/ResourceTests/Data/HC.Test.xaml" />
                 <ut:TestDictionary Name="Default">
                     <!-- Window Control Properties -->
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
-                    <!-- not defined in wpf code-->
+                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />                   
                     <!--<SolidColorBrush x:Key="Window_BorderBrush" Color="{StaticResource TextFillColorPrimary}"/>
                     <Thickness x:Key="Window_BorderThickness">11,5,11,6</Thickness>-->
                     <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource SystemColorWindowTextColor}"/>
@@ -85,15 +72,8 @@
                 </ut:TestDictionary>
 
                 <ut:TestDictionary Name="CanResizeGrip_NormalWindow">
-                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent" />
-                    <SolidColorBrush x:Key="Window_Foreground" Color="{StaticResource SystemColorWindowTextColor}"/>
-                </ut:TestDictionary>
-
-                <ut:TestDictionary Name="Disabled">
-                    <SolidColorBrush x:Key="Window_Background" Color="Transparent"/>
-                </ut:TestDictionary>
-
+                    <Visibility x:Key="WindowResizeGrip_Visibility">Visible</Visibility>                   
+                </ut:TestDictionary>              
 
             </ut:TestDictionary.MergedDictionaries>
         </ut:TestDictionary>

--- a/tests/Fluent.UITests/ControlTests/WindowTests.cs
+++ b/tests/Fluent.UITests/ControlTests/WindowTests.cs
@@ -1,0 +1,177 @@
+﻿using Fluent.UITests.FluentAssertions;
+using Fluent.UITests.TestUtilities;
+using FluentAssertions.Execution;
+using System.Drawing.Imaging;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using Xunit.Abstractions;
+
+namespace Fluent.UITests.ControlTests
+{
+    public class WindowTests :BaseControlTests
+    {
+        public WindowTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+            SetupWindow();
+        }
+
+        [WpfTheory]
+        [MemberData(nameof(ColorModes_TestData))]
+        public void Window_Initialization_Test(ColorMode colorMode)
+        {
+            SetColorMode(TestWindow, colorMode);
+            TestWindow.Show();
+
+            ResourceDictionary rd = GetTestDataDictionary(colorMode, "");
+            VerifyControlProperties(TestWindow, rd);
+        }
+
+        [WpfTheory]
+        [MemberData(nameof(ColorModes_TestData))]
+        public void Window_ResizeMode_Test(ColorMode colorMode)
+        {
+            SetColorMode(TestWindow, colorMode);
+            TestWindow.ResizeMode = ResizeMode.CanResizeWithGrip;
+            TestWindow.WindowState = WindowState.Minimized;
+            TestWindow.Show();
+
+            ResourceDictionary rd = GetTestDataDictionary(colorMode, "");
+            VerifyControlProperties(TestWindow, rd);
+        }
+        [WpfTheory]
+        [MemberData(nameof(ColorModes_TestData))]
+        public void Window_ResizeMode_Test2(ColorMode colorMode)
+        {
+            SetColorMode(TestWindow, colorMode);
+            TestWindow.ResizeMode = ResizeMode.CanResizeWithGrip;
+            TestWindow.WindowState = WindowState.Normal;
+            TestWindow.Show();
+
+            ResourceDictionary rd = GetTestDataDictionary(colorMode, "CanResizeGrip_NormalWindow");
+            VerifyControlProperties(TestWindow, rd);
+        }
+
+        [WpfTheory]
+        [MemberData(nameof(ColorModes_TestData))]
+        public void Window_Disabled_Test(ColorMode colorMode)
+        {
+            SetColorMode(TestWindow, colorMode);
+            TestWindow.IsEnabled = false;        
+            TestWindow.Show();
+
+            ResourceDictionary rd = GetTestDataDictionary(colorMode, "Disabled");
+            VerifyControlProperties(TestWindow, rd);
+        }
+
+        #region Override Methods
+
+        public override List<FrameworkElement> GetStyleParts(Control element)
+        {
+            List<FrameworkElement> templateParts = new List<FrameworkElement>();
+            templateParts.Add(element);
+
+            //ContentPresenter? contentPresenter = element.Template.FindName("ContentPresenter", element) as ContentPresenter;
+            //contentPresenter.Should().NotBeNull();
+            //templateParts.Add(contentPresenter);
+
+            ResizeGrip? windowResizeGrip = element.Template.FindName("WindowResizeGrip", element) as ResizeGrip;
+            if (windowResizeGrip != null) { 
+            windowResizeGrip.Should().NotBeNull();
+            templateParts.Add(windowResizeGrip);
+        }
+            return templateParts;
+        }
+
+        public override void VerifyControlProperties(FrameworkElement element, ResourceDictionary expectedProperties)
+        {
+            Window? window = element as Window;
+            if (window is null) return;
+
+            List<FrameworkElement> parts = GetStyleParts(window);
+
+            Window? part_Window = parts[0] as Window;
+            ResizeGrip? part_ResizeGrip = null;
+            //ContentPresenter? part_ContentPresenter = parts[1] as ContentPresenter;
+            if (parts.Count > 1) { 
+            part_ResizeGrip = parts[1] as ResizeGrip;
+            }
+            using (new AssertionScope())
+            {
+                
+                //validate window properties
+                VerifyWindowProperties(part_Window, expectedProperties);
+                
+                if(part_ResizeGrip != null)
+                {
+                    //validate window resize grip properties
+                    VerifyWindowResizeGripProperties(part_ResizeGrip, expectedProperties);
+                }                
+            }
+        }
+
+        public static void VerifyWindowProperties(Window part_Window, ResourceDictionary expectedProperties)
+        {
+            part_Window.Should().NotBeNull();
+            BrushComparer.Equal(part_Window.Background, (Brush)expectedProperties["Window_Background"]).Should().BeTrue();
+            if (!BrushComparer.Equal(part_Window.Background, (Brush)expectedProperties["Window_Background"]))
+            {
+                Console.WriteLine("part_Window.Background does not match expected value");
+                BrushComparer.LogBrushDifference(part_Window.Background, (Brush)expectedProperties["Window_Background"]);
+            }
+
+            BrushComparer.Equal(part_Window.Foreground, (Brush)expectedProperties["Window_Foreground"]).Should().BeTrue();
+            if (!BrushComparer.Equal(part_Window.Foreground, (Brush)expectedProperties["Window_Foreground"]))
+            {
+                Console.WriteLine("part_Window.Foreground does not match expected value");
+                BrushComparer.LogBrushDifference(part_Window.Foreground, (Brush)expectedProperties["Window_Foreground"]);
+            }
+            // part_Window.BorderThickness.Should().Be((Thickness)expectedProperties["Button_BorderThickness"]);
+        }
+
+        public static void VerifyWindowResizeGripProperties(ResizeGrip part_ResizeGrip, ResourceDictionary expectedProperties)
+        {
+            part_ResizeGrip.Should().NotBeNull();
+            BrushComparer.Equal(part_ResizeGrip.Background, (Brush)expectedProperties["Window_Background"]).Should().BeTrue();
+            if (!BrushComparer.Equal(part_ResizeGrip.Background, (Brush)expectedProperties["Window_Background"]))
+            {
+                Console.WriteLine("part_Window.Background does not match expected value");
+                BrushComparer.LogBrushDifference(part_ResizeGrip.Background, (Brush)expectedProperties["Window_Background"]);
+            }
+            BrushComparer.Equal(part_ResizeGrip.Foreground, (Brush)expectedProperties["Window_Foreground"]).Should().BeTrue();
+            if (!BrushComparer.Equal(part_ResizeGrip.Foreground, (Brush)expectedProperties["Window_Foreground"]))
+            {
+                Console.WriteLine("part_Window.Foreground does not match expected value");
+                BrushComparer.LogBrushDifference(part_ResizeGrip.Foreground, (Brush)expectedProperties["Window_Foreground"]);
+            }
+            part_ResizeGrip.Visibility.Should().Be((Visibility)expectedProperties["WindowResizeGrip_Visibility"]);
+            part_ResizeGrip.IsTabStop.Should().Be((bool)expectedProperties["WindowResizeGrip_IsTabStop"]);
+            part_ResizeGrip.HorizontalAlignment.Should().Be((HorizontalAlignment)expectedProperties["WindowResizeGrip_HorizontalAlignment"]);
+            part_ResizeGrip.VerticalAlignment.Should().Be((VerticalAlignment)expectedProperties["WindowResizeGrip_VerticalAlignment"]);           
+        }
+        #endregion
+
+        #region Private Methods      
+
+        private void SetupWindow()
+        {
+            TestWindow = new Window() { Content = "TestWindow" };
+           // Window = new Window() { Content = "Hello" };
+            //AddControlToView1(TestWindow, Window);
+        }
+
+        #endregion
+
+        #region Private Properties
+
+        //private Window Window { get; set; }
+       // private Dictionary<ColorMode, Window> Windows { get; set; } = new Dictionary<ColorMode, Window>();
+        protected override string TestDataDictionaryPath => @"/Fluent.UITests;component/ControlTests/Data/WindowTests.xaml";
+
+        #endregion
+        private ITestOutputHelper _outputHelper;
+    }
+}

--- a/tests/Fluent.UITests/ControlTests/WindowTests.cs
+++ b/tests/Fluent.UITests/ControlTests/WindowTests.cs
@@ -1,11 +1,6 @@
-﻿using Fluent.UITests.FluentAssertions;
-using Fluent.UITests.TestUtilities;
+﻿using Fluent.UITests.TestUtilities;
 using FluentAssertions.Execution;
-using System.Drawing.Imaging;
-using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
 using Xunit.Abstractions;
 
@@ -29,22 +24,10 @@ namespace Fluent.UITests.ControlTests
             ResourceDictionary rd = GetTestDataDictionary(colorMode, "");
             VerifyControlProperties(TestWindow, rd);
         }
-
+     
         [WpfTheory]
         [MemberData(nameof(ColorModes_TestData))]
         public void Window_ResizeMode_Test(ColorMode colorMode)
-        {
-            SetColorMode(TestWindow, colorMode);
-            TestWindow.ResizeMode = ResizeMode.CanResizeWithGrip;
-            TestWindow.WindowState = WindowState.Minimized;
-            TestWindow.Show();
-
-            ResourceDictionary rd = GetTestDataDictionary(colorMode, "");
-            VerifyControlProperties(TestWindow, rd);
-        }
-        [WpfTheory]
-        [MemberData(nameof(ColorModes_TestData))]
-        public void Window_ResizeMode_Test2(ColorMode colorMode)
         {
             SetColorMode(TestWindow, colorMode);
             TestWindow.ResizeMode = ResizeMode.CanResizeWithGrip;
@@ -53,36 +36,21 @@ namespace Fluent.UITests.ControlTests
 
             ResourceDictionary rd = GetTestDataDictionary(colorMode, "CanResizeGrip_NormalWindow");
             VerifyControlProperties(TestWindow, rd);
-        }
-
-        [WpfTheory]
-        [MemberData(nameof(ColorModes_TestData))]
-        public void Window_Disabled_Test(ColorMode colorMode)
-        {
-            SetColorMode(TestWindow, colorMode);
-            TestWindow.IsEnabled = false;        
-            TestWindow.Show();
-
-            ResourceDictionary rd = GetTestDataDictionary(colorMode, "Disabled");
-            VerifyControlProperties(TestWindow, rd);
-        }
+        }        
 
         #region Override Methods
 
         public override List<FrameworkElement> GetStyleParts(Control element)
         {
             List<FrameworkElement> templateParts = new List<FrameworkElement>();
-            templateParts.Add(element);
-
-            //ContentPresenter? contentPresenter = element.Template.FindName("ContentPresenter", element) as ContentPresenter;
-            //contentPresenter.Should().NotBeNull();
-            //templateParts.Add(contentPresenter);
+            templateParts.Add(element);            
 
             ResizeGrip? windowResizeGrip = element.Template.FindName("WindowResizeGrip", element) as ResizeGrip;
-            if (windowResizeGrip != null) { 
-            windowResizeGrip.Should().NotBeNull();
-            templateParts.Add(windowResizeGrip);
-        }
+            if (windowResizeGrip != null)
+            {
+                windowResizeGrip.Should().NotBeNull();
+                templateParts.Add(windowResizeGrip);
+            }
             return templateParts;
         }
 
@@ -95,16 +63,14 @@ namespace Fluent.UITests.ControlTests
 
             Window? part_Window = parts[0] as Window;
             ResizeGrip? part_ResizeGrip = null;
-            //ContentPresenter? part_ContentPresenter = parts[1] as ContentPresenter;
+           
             if (parts.Count > 1) { 
             part_ResizeGrip = parts[1] as ResizeGrip;
             }
             using (new AssertionScope())
-            {
-                
+            {                
                 //validate window properties
-                VerifyWindowProperties(part_Window, expectedProperties);
-                
+                VerifyWindowProperties(part_Window, expectedProperties);                
                 if(part_ResizeGrip != null)
                 {
                     //validate window resize grip properties
@@ -113,7 +79,7 @@ namespace Fluent.UITests.ControlTests
             }
         }
 
-        public static void VerifyWindowProperties(Window part_Window, ResourceDictionary expectedProperties)
+        public static void VerifyWindowProperties(Window? part_Window, ResourceDictionary expectedProperties)
         {
             part_Window.Should().NotBeNull();
             BrushComparer.Equal(part_Window.Background, (Brush)expectedProperties["Window_Background"]).Should().BeTrue();
@@ -128,8 +94,7 @@ namespace Fluent.UITests.ControlTests
             {
                 Console.WriteLine("part_Window.Foreground does not match expected value");
                 BrushComparer.LogBrushDifference(part_Window.Foreground, (Brush)expectedProperties["Window_Foreground"]);
-            }
-            // part_Window.BorderThickness.Should().Be((Thickness)expectedProperties["Button_BorderThickness"]);
+            }            
         }
 
         public static void VerifyWindowResizeGripProperties(ResizeGrip part_ResizeGrip, ResourceDictionary expectedProperties)
@@ -158,17 +123,12 @@ namespace Fluent.UITests.ControlTests
 
         private void SetupWindow()
         {
-            TestWindow = new Window() { Content = "TestWindow" };
-           // Window = new Window() { Content = "Hello" };
-            //AddControlToView1(TestWindow, Window);
+            TestWindow = new Window() { Content = "TestWindow" };          
         }
 
         #endregion
 
-        #region Private Properties
-
-        //private Window Window { get; set; }
-       // private Dictionary<ColorMode, Window> Windows { get; set; } = new Dictionary<ColorMode, Window>();
+        #region Private Properties                
         protected override string TestDataDictionaryPath => @"/Fluent.UITests;component/ControlTests/Data/WindowTests.xaml";
 
         #endregion


### PR DESCRIPTION
This PR introduces tests for Window UI properties, ensuring that the values are correctly validated.

Notes:
1. The BorderBrush and BorderThickness property values are not declared in the Fluent theme.
2. The ContentPresenter UI properties are not set in the Fluent theme.
3. Disabled properties are also not set in the Fluent theme.